### PR TITLE
Add upper constraint to force "old" toolkit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jaimergp @jchodera @mikemhenry @peastman
+* @ijpulidos @jaimergp @jchodera @mikemhenry @peastman

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@ijpulidos](https://github.com/ijpulidos/)
 * [@jaimergp](https://github.com/jaimergp/)
 * [@jchodera](https://github.com/jchodera/)
 * [@mikemhenry](https://github.com/mikemhenry/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - lxml
     - networkx
     - tinydb
-    - openff-toolkit >=0.9.0
+    - openff-toolkit >=0.9.0,<0.11.0
     - openff-forcefields >=1.2.0
     - validators
 


### PR DESCRIPTION
Until we get https://github.com/openmm/openmmforcefields/pull/225 figured out, it would be nice to avoid users accidentally pulling down a version of the toolkit that is currently incompatible with this release.

Generally the solver likes to find the build with the greatest build number, even if a different built might lead to a quicker solution. No guarantees but recent history with this approach helps the older builds not show up in environments.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
